### PR TITLE
カテゴリー機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,4 @@ gem 'font-awesome-sass'
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
+gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,10 @@ GEM
     io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     kgio (2.11.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -300,6 +304,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,7 +9,7 @@
 //
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
-//
+//= require jquery
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,17 +1,86 @@
-window.addEventListener("load", function() {
-  let parent = document.querySelector("select#parent");
-  console.log(parent)
-  parent.addEventListener("change", function() {
-    let parentValue = parent.value;
-    console.log(parentValue)
-    if(parentValue === "選択して下さい") {
-      parent.addEventListener("blur", function() {
-        console.log("フォーカスから離れました");
-        // 子カテゴリーのセレクトタグを隠す実装が必要
+$(function(){
+  // カテゴリーセレクトボックスのオプションを作成
+  function appendOption(category){
+    let html = `<option value="${category.name}" data-category="${category.id}">${category.name}</option>`;
+    return html;
+  }
+  // 子カテゴリーの表示作成
+  function appendChildrenBox(insertHTML){
+    let childSelectHtml = '';
+    childSelectHtml = `<div class='listing-select-wrapper' id='children_wrapper'>
+                        <div class='listing-select-wrapper__box'>
+                          <select class="listing-select-wrapper__box--select" id="children_category" name="category_id">
+                            <option value="選択して下さい" data-category="---">選択して下さい</option>
+                            ${insertHTML}
+                          </select>
+                        </div>
+                      </div>`;
+    $('.items__category').append(childSelectHtml);
+  }
+  // 孫カテゴリーの表示作成
+  function appendGrandchildrenBox(insertHTML){
+    let grandchildSelectHtml = `<div class='listing-select-wrapper' id='grandchildren_wrapper'>
+                                  <div class='listing-select-wrapper__box'>
+                                    <select class='listing-select-wrapper__box--select' id='grandchildren_category' name='category_id'>
+                                      <option value='選択して下さい' data-category="---">選択して下さい</option>
+                                      ${insertHTML}
+                                    </select>
+                                  </div>
+                                </div>`;
+    $('.items__category').append(grandchildSelectHtml);
+  }
+  // 親カテゴリー選択後のイベント
+  $('#parent_category').on('change', function(){
+    let parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーの名前を取得
+    if (parentCategory != "選択して下さい"){ //親カテゴリーが初期値の"選択して下さい"でないことを確認
+      $.ajax({
+        url: 'get_children_category',
+        type: 'GET',
+        data: { parent_name: parentCategory },
+        dataType: 'json'
       })
-    } else {
-      console.log("次は子カテゴリーを選択して下さい");
-      
+      .done(function(children){
+        $('#children_wrapper').remove(); //親が変更された時、子以下を削除する
+        $('#grandchildren_wrapper').remove();
+        let insertHTML = '';
+        children.forEach(function(child){
+          insertHTML += appendOption(child);
+        });
+        appendChildrenBox(insertHTML);
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else{
+      $('#children_wrapper').remove(); //親カテゴリーが初期値になった時、子以下を削除するする
+      $('#grandchildren_wrapper').remove();
+    }
+  });
+  // 子カテゴリー選択後のイベント
+  $('.items__category').on("change", '#children_category', function(){
+    let childId = $('#children_category option:selected').data('category'); //選択された子カテゴリーのid取得
+    if (childId != "---"){//子カテゴリーが初期値で無い事を確認
+      $.ajax({
+        url: 'get_grandchildren_category',
+        type: 'GET',
+        data: { child_id: childId},
+        dataType: 'json'
+      })
+      .done(function(grandchildren){
+        if(grandchildren.length != 0){
+          $('#grandchildren_wrapper').remove();//子が変更された時、孫以下を削除する
+          let insertHTML = '';
+          grandchildren.forEach(function(grandchild){
+            insertHTML += appendOption(grandchild);
+          });
+          appendGrandchildrenBox(insertHTML);
+        }
+      })
+      .fail(function(){
+        alert('カテゴリーの取得に失敗しました');
+      })
+    }else{
+      $('#grandchildren_wrapper').remove(); //子カテゴリーが初期値になった時、孫以下を削除する
     }
   });
 });

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -7,9 +7,9 @@ $(function(){
   // 子カテゴリーの表示作成
   function appendChildrenBox(insertHTML){
     let childSelectHtml = '';
-    childSelectHtml = `<div class='listing-select-wrapper' id='children_wrapper'>
-                        <div class='listing-select-wrapper__box'>
-                          <select class="listing-select-wrapper__box--select" id="children_category" name="category_id">
+    childSelectHtml = `<div class='items-select-wrapper' id='children_wrapper'>
+                        <div class='items-select-wrapper__box'>
+                          <select class="items-select-wrapper__box--select" id="children_category" name="category_id">
                             <option value="選択して下さい" data-category="---">選択して下さい</option>
                             ${insertHTML}
                           </select>
@@ -19,9 +19,9 @@ $(function(){
   }
   // 孫カテゴリーの表示作成
   function appendGrandchildrenBox(insertHTML){
-    let grandchildSelectHtml = `<div class='listing-select-wrapper' id='grandchildren_wrapper'>
-                                  <div class='listing-select-wrapper__box'>
-                                    <select class='listing-select-wrapper__box--select' id='grandchildren_category' name='category_id'>
+    let grandchildSelectHtml = `<div class='items-select-wrapper' id='grandchildren_wrapper'>
+                                  <div class='items-select-wrapper__box'>
+                                    <select class='items-select-wrapper__box--select' id='grandchildren_category' name='category_id'>
                                       <option value='選択して下さい' data-category="---">選択して下さい</option>
                                       ${insertHTML}
                                     </select>
@@ -29,7 +29,7 @@ $(function(){
                                 </div>`;
     $('.items__category').append(grandchildSelectHtml);
   }
-  // 親カテゴリー選択後のイベント
+  // 親カテゴリー選択後のイベント（子カテゴリーのセレクトタグを出す為のAjax通信）
   $('#parent_category').on('change', function(){
     let parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーの名前を取得
     if (parentCategory != "選択して下さい"){ //親カテゴリーが初期値の"選択して下さい"でないことを確認

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -2,7 +2,16 @@ window.addEventListener("load", function() {
   let parent = document.querySelector("select#parent");
   console.log(parent)
   parent.addEventListener("change", function() {
-    console.log("親カテゴリーが選択されました");
-    alert("親カテゴリーが選択されました");
+    let parentValue = parent.value;
+    console.log(parentValue)
+    if(parentValue === "選択して下さい") {
+      parent.addEventListener("blur", function() {
+        console.log("フォーカスから離れました");
+        // 子カテゴリーのセレクトタグを隠す実装が必要
+      })
+    } else {
+      console.log("次は子カテゴリーを選択して下さい");
+      
+    }
   });
 });

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,0 +1,8 @@
+window.addEventListener("load", function() {
+  let parent = document.querySelector("select#parent");
+  console.log(parent)
+  parent.addEventListener("change", function() {
+    console.log("親カテゴリーが選択されました");
+    alert("親カテゴリーが選択されました");
+  });
+});

--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -1,0 +1,8 @@
+// $(function(){
+//   $("#parent").on("change", function(e){
+//     e.preventDefault();
+//     console.log(this);
+//     let parentData = new FormData(this);
+//     let url = $(this).attr("value");
+//   })
+// });

--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -1,8 +1,0 @@
-// $(function(){
-//   $("#parent").on("change", function(e){
-//     e.preventDefault();
-//     console.log(this);
-//     let parentData = new FormData(this);
-//     let url = $(this).attr("value");
-//   })
-// });

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,11 +7,10 @@ class ItemsController < ApplicationController
     @item = Item.new
     @conditions = Condition.all
     @prefectures = Prefecture.all
-    @parent_category = ["選択して下さい"]
     # 親カテゴリーのデータを取り出して名前の要素を配列に追加していく
-    Category.where(ancestry: nil).each do |parent|
-      @parent_category << parent.name
-    end
+    # pluckメソッドで指定したカラムのレコードの配列を取得する
+    # unshiftメソッドで配列の先頭に要素を挿入（カテゴリー選択の初期値"選択して下さい"を挿入)
+    @parent_category =Category.where(ancestry: nil).pluck(:name).unshift("選択して下さい")
   end
 
   # 親カテゴリーが選択された後の子カテゴリーのアクション

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,10 +7,22 @@ class ItemsController < ApplicationController
     @item = Item.new
     @conditions = Condition.all
     @prefectures = Prefecture.all
-    @parent = ["選択して下さい"]
+    @parent_category = ["選択して下さい"]
     Category.where(ancestry: nil).each do |parent|
-      @parent << parent.name
+      @parent_category << parent.name
     end
+  end
+
+  # 親カテゴリーが選択された後の子カテゴリーのアクション
+  def get_children_category
+    # 選択された親カテゴリーに紐づく子カテゴリーの配列を取得
+    @children_category = Category.find_by(name: "#{params[:parent_name]}", ancestry: nil).children
+  end
+
+  # 子カテゴリーが選択された後の孫カテゴリーのアクション
+  def get_grandchildren_category
+    # 選択された子カテゴリーに紐づく孫カテゴリーの配列を取得
+    @grandchildren_category = Category.find(params[:child_id]).children
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,10 @@ class ItemsController < ApplicationController
     @item = Item.new
     @conditions = Condition.all
     @prefectures = Prefecture.all
+    @parent = ["選択して下さい"]
+    Category.where(ancestry: nil).each do |parent|
+      @parent << parent.name
+    end
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,7 @@ class ItemsController < ApplicationController
     @conditions = Condition.all
     @prefectures = Prefecture.all
     @parent_category = ["選択して下さい"]
+    # 親カテゴリーのデータを取り出して名前の要素を配列に追加していく
     Category.where(ancestry: nil).each do |parent|
       @parent_category << parent.name
     end

--- a/app/views/items/get_children_category.json.jbuilder
+++ b/app/views/items/get_children_category.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @children_category do |child|
+  json.id child.id
+  json.name child.name
+end

--- a/app/views/items/get_grandchildren_category.json.jbuilder
+++ b/app/views/items/get_grandchildren_category.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @grandchildren_category do |grandchild|
+  json.id grandchild.id
+  json.name grandchild.name
+end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -28,11 +28,12 @@
     .items__category
       .label カテゴリー
       %span.require 必須
-      .select-wrap
-      %i.icon-arrow-button
-      -# categorysテーブルのidを呼びだす実装が必要
+      -# categorysテーブルのidを呼びだす実装が必  
       = form_with(model: @item, local: true) do |f|
-        = f.collection_select :category_id, Category.all, :id, :name, prompt: "選択して下さい", class: 'select'
+        -# = f.collection_select :category_id, Category.all, :id, :name, prompt: "選択して下さい", class: 'select'
+        = f.select :category, @parent, {}, {class: 'select parent', id: 'parent'}
+        /↓セレクトタグの矢印を出来ればもっとカッコよくしたい用
+        -# %i.fas.fa-chevron-down
     .items__brand
       %br
       .label ブランド
@@ -43,19 +44,15 @@
       .label 商品の状態
       %span.require 必須
       %br
-      .select-wrap
-      %i.icon-arrow-button
       -# active_hashで作ったconditionモデルの値を表示させる
       = form_with(model: @item, local: true) do |f|
-        = f.collection_select :condition_id, Condition.all, :id, :condition, prompt: "選択して下さい", class: 'select'
+        = f.collection_select :condition_id, Condition.all, :id, :condition, prompt: "選択して下さい", class: 'select condition'
         
   .deliverys
     .items__fee
       .items__fee__title 配送について
       .label 配送料の負担
       %span.require 必須
-      .select-wrap
-      %i.icon-arow-button
       = form_with(model: @item, local: true) do |f|
         = f.select :fee, {'選択して下さい': "null", "送料込み(出品者負担)": "送料込み(出品者負担)", "着払い(購入者負担)": "着払い(購入者負担)"}
     .items__consignor
@@ -66,7 +63,7 @@
       -# active_hashのprefectureモデルの値を表示させる
       -# DB確認したらprefecture_idカラムが無いので、アソシエーションの追加が必要だと思われる
       = form_with(model: @item, local: true) do |f|
-        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択して下さい", class: 'select'
+        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択して下さい", class: 'select prefecture'
     .items__delivery_day
       .label 発送までの日数
       %span.require 必須

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,5 +1,6 @@
 -# 部分テンプレートのヘッダー
 = render partial: 'devise/registrations/furima.header'
+-# 商品画像をアップロードする実装
 .items
   .items__information
     .items__image
@@ -12,7 +13,7 @@
         .camera_icon__comment
           %br
           ドラッグアンドドロップ</br>またはクリックしてファイルをアップロード
-      
+      -# 商品名や説明を入れる
     .items__name
       .label 商品名
       %span.require 必須
@@ -22,17 +23,17 @@
       %span.require 必須
       %br
       %textarea{cols: "1000", name: "kanso", rows: "7", placeholder: "商品の説明(必須1,000文字以内)\n(色、素材、重さ、定価、注意点など）"}
-
+    -# 商品の詳細を入れる
   .items__edit 
     .items__edit__title 商品の詳細
     .items__category
       .label カテゴリー
       %span.require 必須
-      .listing-select-wrapper
-        .listing-select-wrapper__box
-          -# categorysテーブルのデータを呼び出して動的にセレクトタグを追加させる
+      .items-select-wrapper
+        .items-select-wrapper__box
+          -# categorysテーブルのデータを呼び出して動的にセレクトタグを追加させる（親→子→孫）
           = form_with(model: @item, local: true, id: "category") do |f|
-            = f.select :category, @parent_category, {}, {class: 'listing-select-wrapper__box--select', id: 'parent_category'}
+            = f.select :category, @parent_category, {}, {class: 'items-select-wrapper__box--select', id: 'parent_category'}
     .items__brand
       %br
       .label ブランド
@@ -46,7 +47,7 @@
       -# active_hashで作ったconditionモデルの値を表示させる
       = form_with(model: @item, local: true) do |f|
         = f.collection_select :condition_id, Condition.all, :id, :condition, prompt: "選択して下さい", class: 'select condition'
-     
+  -# 配送に関係する内容 
   .deliverys
     .items__fee
       .items__fee__title 配送について
@@ -70,6 +71,7 @@
       %i.icon-arow-button
       = form_with(model: @item, local: true) do |f|
         = f.select :delivery_day, {'選択して下さい': "null", "1~2日で発送": "1~2日で発送", "2~3日で発送": "2~3日で発送", "4~7日で発送": "4~7日で発送"}
+  -# 価格に関する入力
   .price
     価格 (¥300~9,999,999)
     .items__price
@@ -84,6 +86,7 @@
     .items__profit
       販売利益
       .items__profit__notation ー
+  -# 出品ボタン
   .exhibition
     .exhibition__btn
       .exhibition__btn__red 出品する

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -32,8 +32,7 @@
       = form_with(model: @item, local: true) do |f|
         -# = f.collection_select :category_id, Category.all, :id, :name, prompt: "選択して下さい", class: 'select'
         = f.select :category, @parent, {}, {class: 'select parent', id: 'parent'}
-        /↓セレクトタグの矢印を出来ればもっとカッコよくしたい用
-        -# %i.fas.fa-chevron-down
+       
     .items__brand
       %br
       .label ブランド

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -28,11 +28,11 @@
     .items__category
       .label カテゴリー
       %span.require 必須
-      -# categorysテーブルのidを呼びだす実装が必  
-      = form_with(model: @item, local: true) do |f|
-        -# = f.collection_select :category_id, Category.all, :id, :name, prompt: "選択して下さい", class: 'select'
-        = f.select :category, @parent, {}, {class: 'select parent', id: 'parent'}
-       
+      .listing-select-wrapper
+        .listing-select-wrapper__box
+          -# categorysテーブルのデータを呼び出して動的にセレクトタグを追加させる
+          = form_with(model: @item, local: true, id: "category") do |f|
+            = f.select :category, @parent_category, {}, {class: 'listing-select-wrapper__box--select', id: 'parent_category'}
     .items__brand
       %br
       .label ブランド
@@ -46,7 +46,7 @@
       -# active_hashで作ったconditionモデルの値を表示させる
       = form_with(model: @item, local: true) do |f|
         = f.collection_select :condition_id, Condition.all, :id, :condition, prompt: "選択して下さい", class: 'select condition'
-        
+     
   .deliverys
     .items__fee
       .items__fee__title 配送について

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,13 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
-  resources :items, only: [:index, :new, :show]
+  resources :items, only: [:index, :new, :show] do
+  #Ajaxで動くアクションのルートの作成
+    collection do
+      get 'get_category_children', defaults: { format: 'json' }
+      get 'get_category_grandchildren', defaults: { format: 'json' }
+    end
+  end
   resources :users, only: [:new, :show, :index, :edit]
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,4 @@ Rails.application.routes.draw do
     end
   end
   resources :users, only: [:new, :show, :index, :edit]
-
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
   resources :items, only: [:index, :new, :show] do
   #Ajaxで動くアクションのルートの作成
     collection do
-      get 'get_category_children', defaults: { format: 'json' }
-      get 'get_category_grandchildren', defaults: { format: 'json' }
+      get 'get_children_category', defaults: { format: 'json' }
+      get 'get_grandchildren_category', defaults: { format: 'json' }
     end
   end
   resources :users, only: [:new, :show, :index, :edit]


### PR DESCRIPTION
#WHAT

商品出品ページにあるカテゴリ検索機能を実装しました。
概要は下記の通りです。

・セレクトタグから親カテゴリーを選択すると、直下に選択したカテゴリーに紐づく子カテゴリーのセレクトタグが追加表示される。

・同じく追加された子カテゴリーのセレクトタグからカテゴリーを選択すると、直下に選択したカテゴリーに紐づく孫カテゴリーのセレクトタグが追加表示される。

・親カテゴリーまたは子カテゴリーの選択を変えると、直下のカテゴリーのデータも変更される

・親カテゴリーまたは子カテゴリーの選択を初期値（”選択しない”）にすると、直下のカテゴリーの表示が無くなる

※先行して作成済みとの出品ページとはこの後にマージ予定ですので、一旦はローカルリポジトリで作成して挙動を確認したビューを添付します。

#WHY
最終課題の必須機能実装の為

<img width="711" alt="スクリーンショット 2020-09-10 9 41 32" src="https://user-images.githubusercontent.com/61212485/92668807-cc5d0880-f34a-11ea-9c50-de726843cd26.png">
