### PR TITLE
ウィザード形式でのユーザー情報、住所登録

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -9,17 +9,39 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # POST /resource
   def create
     @user = User.new(sign_up_params)
-    if @user.save
-      flash[:success] = "ユーザを登録しました"
-      redirect_to root_path
-    else
-      flash[:danger] = "ユーザの登録に失敗しました"
+    unless @user.valid?
+      flash.now[:alert] = @user.errors.full_messages
       render :new and return
     end
+
+    session["devise.regist_data"] = {user: @user.attributes}
+    session["devise.regist_data"][:user]["password"] = params[:user][:password]
+    @residency = @user.build_residency
+    render :new_residency
   end
 
+  def new_residency
+  end
+
+  def create_residency
+    @user = User.new(session["devise.regist_data"]["user"])
+    @residency = Residency.new(residency_params)
+    unless @residency.valid?
+      flash.now[:alert] = @residency.errors.full_messages
+      render :new_residency and return
+    end
+    @user.build_residency(@residency.attributes)
+    @user.save
+    redirect_to root_path
+  end
+
+  protected
 
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :family_name, :first_name, :family_name_reading, :first_name_reading, :birth_day])
+  end
+
+  def residency_params
+    params.require(:residency).permit(:prefecture_id, :family_name, :first_name, :family_name_reading, :first_name_reading, :city, :address, :zip_code, :building, :phone)
   end
 end

--- a/app/models/residency.rb
+++ b/app/models/residency.rb
@@ -1,8 +1,6 @@
 class Residency < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
-  belongs_to :user
   belongs_to :prefecture
-  has_one :consignors
-
+  belongs_to :user, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,13 +3,10 @@ class User < ApplicationRecord
         # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
         devise :database_authenticatable, :registerable,
                 :recoverable, :rememberable, :validatable
-        has_one :consignor
         has_many :items
-        has_many :residencys
+        has_one :residency, dependent: :delete
 
-
-
-#以下はフリマのバリデーションコード
+        #以下はフリマのバリデーションコード
         validates :nickname, :password_confirmation, :birth_day, :family_name, :first_name, :family_name_reading, :first_name_reading, presence: true
         validates :email, uniqueness: {case_sensitive: true},
                 format: {with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i}

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,7 +2,7 @@
 
 .furima-contents
   .furima-main
-    %h2.furima-main__title 会員入力情報
+    %h2.furima-main__title 会員情報入力
     = form_for(resource, as: resource_name, url: registration_path(resource_name, class: "signup-main__form")) do |f|
       .furima-main__form
         = f.label :nickname, "ニックネーム"

--- a/app/views/devise/registrations/new_residency.html.haml
+++ b/app/views/devise/registrations/new_residency.html.haml
@@ -1,8 +1,7 @@
-newaddress.html.haml
 .furima-contents
   .furima-main
     %h2.furima-main__title 住所登録
-    = form_for("#") do |f|
+    = form_for @residency do |f|
       .furima-main__form
         %label お名前（全角）
         %span.require 必須
@@ -34,16 +33,8 @@ newaddress.html.haml
         %span.require 必須
         = f.text_field :address, autofocus: true, placeholder: "例) 1-1-1", class: "form-input"
       .furima-main__form
-        = f.label :city, "市区町村"
-        %span.require 必須
-        = f.text_field :city, autofocus: true, placeholder: "例) 大阪市中央区", class: "form-input"
-      .furima-main__form
         = f.label :building, "建物名"
         %span.require 必須
-        = f.text_field :building, autofocus: true, placeholder: "例) 柳ビル", class: "form-input"
-      .furima-main__form
-        = f.label :building, "建物名"
-        %span.nonrequire 任意
         = f.text_field :building, autofocus: true, placeholder: "例) 柳ビル", class: "form-input"
       .furima-main__form
         = f.label :phone, "電話番号"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,12 @@
 Rails.application.routes.draw do
+  root 'items#index'
   devise_for :users, controllers: {
     registrations: 'users/registrations',
   } 
-  root 'items#index'
+  devise_scope :user do
+    get  'residencies', to: 'users/registrations#new_residency'
+    post 'residencies', to: 'users/registrations#create_residency'
+  end
   resources :items, only: [:index, :new, :show] do
   #Ajaxで動くアクションのルートの作成
     collection do

--- a/db/migrate/20200824123715_create_residencies.rb
+++ b/db/migrate/20200824123715_create_residencies.rb
@@ -10,7 +10,7 @@ class CreateResidencies < ActiveRecord::Migration[5.2]
       t.integer :address,            null: false
       t.integer :zip_code,           null: false
       t.string :building
-      t.integer :phone
+      t.string :phone
       t.integer :user_id,            null: false,foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,22 @@
 
 ActiveRecord::Schema.define(version: 2020_09_07_114227) do
 
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prefecture_id"
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_name_reading", null: false
+    t.string "first_name_reading", null: false
+    t.string "city", null: false
+    t.integer "address", null: false
+    t.integer "zip_code", null: false
+    t.string "building"
+    t.integer "phone"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -65,7 +81,7 @@ ActiveRecord::Schema.define(version: 2020_09_07_114227) do
     t.integer "address", null: false
     t.integer "zip_code", null: false
     t.string "building"
-    t.integer "phone"
+    t.string "phone"
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
#What
ウィザード形式で、ユーザーの基本情報の登録と住所登録を行えるようにした。ユーザー登録のコントローラーで一時的に情報を保持した状態で住所入力のページへ遷移することで、住所がユーザー情報と紐付けられる形で登録することができる。
（バリデーション、テスト、ログインについては現状未実装でありあくまで登録ができるのみの状態です。）

#Why
ウィザード形式によってユーザー情報、住所登録が同時に行え管理しやすく、ユーザーも登録しやすくなるため。