### PR TITLE
エラーハンドリングの実施

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,4 @@ gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
 gem "jquery-rails"
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.3)
       actionpack (= 5.2.4.3)
       activesupport (= 5.2.4.3)
@@ -335,6 +338,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "reset";
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "flash";
 @import "userpage";
 @import "link-text";
 @import "sidebar";

--- a/app/assets/stylesheets/flash.scss
+++ b/app/assets/stylesheets/flash.scss
@@ -1,0 +1,13 @@
+.notification {
+  .notice {
+    background-color: #38AE80;
+    color: white;
+    text-align: center;
+  }
+
+  .alert {
+    background-color: #F35500;
+    color: white;
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -60,6 +60,7 @@
   background: #ea352d;
   border: 1px solid #ea352d;
   color: #fff;
+  text-align: center;
 }
 
 .forget_password {

--- a/app/assets/stylesheets/new-users.scss
+++ b/app/assets/stylesheets/new-users.scss
@@ -13,6 +13,8 @@
           margin :0 auto;
           max-width: 300px;
           text-align: center;
+          font-size: 18px;
+          font-weight: bold;
         }
         &__form {
           margin: auto;

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,7 +10,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     @user = User.new(sign_up_params)
     unless @user.valid?
-      flash.now[:alert] = @user.errors.full_messages
+      @user.errors.full_messages
+      flash.now[:alert] = "誤りや記入漏れがあります。下記を参照に修正してください。"
       render :new and return
     end
 
@@ -27,13 +28,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
     @user = User.new(session["devise.regist_data"]["user"])
     @residency = Residency.new(residency_params)
     unless @residency.valid?
-      flash.now[:alert] = @residency.errors.full_messages
+      @residency.errors.full_messages
+      flash.now[:alert] = "誤りや記入漏れがあります。下記を参照に修正してください。"
       render :new_residency and return
     end
     @user.build_residency(@residency.attributes)
     @user.save
     sign_in(:user, @user)
-    redirect_to root_path
+    redirect_to root_path, notice: '登録ができました'
   end
 
   protected

--- a/app/models/residency.rb
+++ b/app/models/residency.rb
@@ -3,4 +3,15 @@ class Residency < ApplicationRecord
   belongs_to_active_hash :prefecture
   belongs_to :prefecture
   belongs_to :user, optional: true
+
+  with_options presence: true do
+    validates :zip_code, format:{ with: /\A\d{3}[-]\d{4}\z/}
+    validates :prefecture_id
+    validates :city
+    validates :address
+    validates :family_name
+    validates :first_name
+    validates :family_name_reading
+    validates :first_name_reading
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,9 @@ class User < ApplicationRecord
         has_one :residency, dependent: :delete
 
         #以下はフリマのバリデーションコード
-        validates :nickname, :password_confirmation, :birth_day, :family_name, :first_name, :family_name_reading, :first_name_reading, presence: true
+        with_options presence: true do
+        validates :nickname
+        validates :birth_day
         validates :email, uniqueness: {case_sensitive: true},
                 format: {with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i}
         validates :password, length: {minimum: 7}
@@ -19,5 +21,5 @@ class User < ApplicationRecord
                 format: { with: /\A([ァ-ン]|ー)+\z/, message: 'を全角カタカナで入力してください' }
         validates :first_name_reading,
                 format: { with: /\A([ァ-ン]|ー)+\z/, message: 'を全角カタカナで入力してください' }
-
+        end
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,8 +2,9 @@
 
 .furima-contents
   .furima-main
-    %h2.furima-main__title 会員情報入力
+    %h2.furima-main__title 登録ステップ１／２  会員情報入力
     = form_for(resource, as: resource_name, url: registration_path(resource_name, class: "signup-main__form")) do |f|
+      = render "devise/shared/error_messages", resource: resource
       .furima-main__form
         = f.label :nickname, "ニックネーム"
         %span.require 必須

--- a/app/views/devise/registrations/new_residency.html.haml
+++ b/app/views/devise/registrations/new_residency.html.haml
@@ -2,8 +2,9 @@
 
 .furima-contents
   .furima-main
-    %h2.furima-main__title 住所登録
+    %h2.furima-main__title 登録ステップ２／２  商品送付先登録
     = form_for @residency do |f|
+      = render "devise/shared/error_messages", resource: @residency
       .furima-main__form
         %label お名前（全角）
         %span.require 必須

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,0 +1,3 @@
+.notification
+  - flash.each do |key, value|
+    = content_tag :div, value, class: key

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,4 +8,5 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    = render 'layouts/notifications'
     = yield

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module FleamarketSample77d
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,57 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        created_at: 作成日
+        email: メールアドレス
+        encrypted_password: 暗号化パスワード
+        password: パスワード
+        password_confirmation: パスワード再入力
+        family_name: お名前（苗字）
+        first_name: お名前（名前）
+        family_name_reading: 苗字フリガナ
+        first_name_reading: 名前フリガナ
+        birth_day: 生年月日
+        updated_at: 更新日
+      residency:
+        family_name: お名前（苗字）
+        first_name: お名前（名前）
+        family_name_reading: 苗字フリガナ
+        first_name_reading: 名前フリガナ
+        zip_code: 郵便番号
+        city: 市区町村名
+        address: 番地
+        prefecture_id: 都道府県
+
+    models:
+      user: ユーザー
+      residency: 商品送付先住所
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      not_found: は見つかりませんでした。
+      not_saved:
+        one: エラーが発生したため保存されませんでした。もう一度やり直すようよろしくお願いします。
+        other: "下記の入力および訂正をお願いします。"

--- a/db/migrate/20200823051138_devise_create_users.rb
+++ b/db/migrate/20200823051138_devise_create_users.rb
@@ -5,7 +5,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
     create_table :users do |t|
       ## Database authenticatable
       t.string :nickname,            null: false 
-      t.string :email,              null: false, default: "", unique: true
+      t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
       t.string :family_name,        null: false
       t.string :first_name,         null: false

--- a/db/migrate/20200824123715_create_residencies.rb
+++ b/db/migrate/20200824123715_create_residencies.rb
@@ -8,7 +8,7 @@ class CreateResidencies < ActiveRecord::Migration[5.2]
       t.string :first_name_reading, null: false
       t.string :city,                null: false
       t.integer :address,            null: false
-      t.integer :zip_code,           null: false
+      t.string :zip_code,           null: false
       t.string :building
       t.string :phone
       t.integer :user_id,            null: false,foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 2020_09_07_114227) do
     t.string "first_name_reading", null: false
     t.string "city", null: false
     t.integer "address", null: false
-    t.integer "zip_code", null: false
+    t.string "zip_code", null: false
     t.string "building"
     t.string "phone"
     t.integer "user_id", null: false


### PR DESCRIPTION
# What 
エラーハンドリングとしてユーザー登録ページでは入力漏れ、間違いがある場合はバリデーションでひっかけ、メッセージを表示できるようにした。メッセージは日本語化し、日本語で表示しユーザーに分かりやすく示した。ユーザー登録ページでバリデーションに引っかかった場合、ユーザー登録できた場合、ログインに成功または失敗した場合はフラッシュメッセージが日本語で表示できるようにした。

# Why
ユーザーがユーザー登録、ログインを行いやすくするため。