### PR TITLE
データベース設計の追加及び変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 ### Association
 - belongs_to :user
 - belongs_to :prefecture
-- has_one :consignors
+- has_one :consignor
 
 ## consignorsテーブル(発送元)
 - 商品送付先住所情報
@@ -155,7 +155,7 @@
 |name|string|null: false|
 
 ### Association
-- has_many :item
+- has_many :items
 
 ## imagesテーブル
 - 画像は1枚以上必須
@@ -177,7 +177,7 @@
 |item_id|integer|null: false, foreign_key: true|
 
 ### Association
-- has_many :item
+- has_many :items
 
 ## soldout(売却済み)テーブル
 - 外部キーとして売却済みを管理する
@@ -187,7 +187,7 @@
 |item_id|integer|null: false, foreign_key: true|
 
 ### Association
-- has_many :item
+- has_many :items
 
 ## ER図（URL）
 https://drive.google.com/file/d/1cq6Yql1uTnw0qAZnIx0Pi92um7jvuVx9/view?usp=sharing

--- a/README.md
+++ b/README.md
@@ -18,29 +18,26 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false|
+|family_name|string|null: false|
+|family_name_reading|string|null: false|
+|first_name|string|null: false|
+|first_name_reading|string|null: false|
 |birthday|integer|null: false|
-|phone|string||
 |nick_name|string|null: false|
 |email|string|null: false, unique:true|
 |password|string|null: false|
-|profile_text|string||
 
 ### Association
 - has_many :credit_cards
 - has_one :consignor
 - has_many :items
-- has_many :residencys
+- has_one :residencys
 
 ## prefectureテーブル（都道府県）
 - 都道府県が必須
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
-
-### Association
-- has_many :residencys
-- has_many :items
 
 ## residencysテーブル(住所)
  - 郵便番号が必須
@@ -50,10 +47,15 @@
 
 |Column|Type|Options|
 |------|----|-------|
+|family_name|string|null: false|
+|family_name_reading|string|null: false|
+|first_name|string|null: false|
+|first_name_reading|string|null: false|
 |city|string|null: false|
 |address|integer|null: false|
-|building|string|null: false|
-|zip_code|integer|null: false|
+|building|string|
+|zip_code|string|null: false|
+|phone|string|
 |user_id|integer|null: false, foreign_key: true|
 |prefecture_id(acitve_hash)|integer|null: false|
 
@@ -137,6 +139,8 @@
 - has_one :consignor
 - belongs_to :condition
 - belongs_to :prefecture
+- belongs_to :exhibit
+- belongs_to :soldout
 
 ## categorysテーブル
 - カテゴリーの情報が必須
@@ -170,6 +174,28 @@
 
 ### Association
 - belongs_to :item
+
+## exhibit(出品中)テーブル
+- 外部キーとして出品中を管理する
+
+|Column|Type|Options|
+|------|----|-------|
+|url|string|null: false|
+|item_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :item
+
+## soldout(売却済み)テーブル
+- 外部キーとして売却済みを管理する
+
+|Column|Type|Options|
+|------|----|-------|
+|url|string|null: false|
+|item_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :item
 
 ## ER図（URL）
 https://drive.google.com/file/d/1cq6Yql1uTnw0qAZnIx0Pi92um7jvuVx9/view?usp=sharing

--- a/README.md
+++ b/README.md
@@ -31,13 +31,7 @@
 - has_many :credit_cards
 - has_one :consignor
 - has_many :items
-- has_one :residencys
-
-## prefectureテーブル（都道府県）
-- 都道府県が必須
-|Column|Type|Options|
-|------|----|-------|
-|name|string|null: false|
+- has_one :residency
 
 ## residencysテーブル(住所)
  - 郵便番号が必須
@@ -180,7 +174,6 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|url|string|null: false|
 |item_id|integer|null: false, foreign_key: true|
 
 ### Association
@@ -191,7 +184,6 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|url|string|null: false|
 |item_id|integer|null: false, foreign_key: true|
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 |family_name_reading|string|null: false|
 |first_name|string|null: false|
 |first_name_reading|string|null: false|
-|birthday|integer|null: false|
+|birthday|date|null: false|
 |nick_name|string|null: false|
 |email|string|null: false, unique:true|
 |password|string|null: false|
@@ -82,22 +82,12 @@
 ## credit_cardsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|card_id|integer||
-|token|string||
+|card_id|integer|null: false|
+|token|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
-
-## conditionsテーブル
-- 商品の状態についての情報が必須
-
-|Column|Type|Options|
-|------|----|-------|
-|condition|integer|null: false|
-
-### Association
-- has_many :items
 
 ## itemsテーブル
 - 画像は1枚以上必須
@@ -169,25 +159,16 @@
 ### Association
 - belongs_to :item
 
-## exhibit(出品中)テーブル
-- 外部キーとして出品中を管理する
-
-|Column|Type|Options|
-|------|----|-------|
-|item_id|integer|null: false, foreign_key: true|
-
-### Association
-- has_many :items
-
 ## soldout(売却済み)テーブル
 - 外部キーとして売却済みを管理する
 
 |Column|Type|Options|
 |------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
 |item_id|integer|null: false, foreign_key: true|
 
 ### Association
-- has_many :items
+- belongs_to :item
 
 ## ER図（URL）
 https://drive.google.com/file/d/1cq6Yql1uTnw0qAZnIx0Pi92um7jvuVx9/view?usp=sharing

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - has_one :consignor
 - has_many :items
 - has_one :residency
+- has_many :soldouts
 
 ## residencysテーブル(住所)
  - 郵便番号が必須
@@ -46,7 +47,7 @@
 |first_name|string|null: false|
 |first_name_reading|string|null: false|
 |city|string|null: false|
-|address|integer|null: false|
+|address|string|null: false|
 |building|string|
 |zip_code|string|null: false|
 |phone|string|
@@ -57,6 +58,7 @@
 - belongs_to :user
 - belongs_to :prefecture
 - has_one :consignor
+- belongs_to_active_hash :prefecture
 
 ## consignorsテーブル(発送元)
 - 商品送付先住所情報
@@ -77,6 +79,7 @@
 ### Association
 - belongs_to :user
 - belongs_to :residency
+- belongs_to_active_hash :prefecture
 
 
 ## credit_cardsテーブル
@@ -121,10 +124,9 @@
 - belongs_to :brand
 - has_many :images
 - has_one :consignor
-- belongs_to :condition
-- belongs_to :prefecture
-- belongs_to :exhibit
-- belongs_to :soldout
+- belongs_to_active_hash :condition
+- belongs_to_active_hash :prefecture
+- has_one :soldout
 
 ## categorysテーブル
 - カテゴリーの情報が必須
@@ -169,6 +171,7 @@
 
 ### Association
 - belongs_to :item
+- belongs_to :user
 
 ## ER図（URL）
 https://drive.google.com/file/d/1cq6Yql1uTnw0qAZnIx0Pi92um7jvuVx9/view?usp=sharing

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@
 
 ### Association
 - belongs_to :user
-- belongs_to :prefecture
 - has_one :consignor
 - belongs_to_active_hash :prefecture
 
@@ -115,8 +114,8 @@
 |category_id|integer|null: false, foreign_key: true|
 |brand_id|integer||
 |consignor_id|integer|null: false, foreign_key: true|
-|condition_id|integer|null: false, foreign_key: true|
-|prefecture_id|integer|null: false, foreign_key: true|
+|condition_id|integer|
+|prefecture_id|integer|
 
 ### Association
 - belongs_to :user


### PR DESCRIPTION
# What
ユーザー登録、商品登録機能を作成中データベースの仕様変更が必要となった。出品の実装として出品中と売却済みをテーブルとして管理する必要がある。その管理方法として出品中テーブルと売却済みテーブルに分け、商品を外部キーとして管理する方法を取った。またユーザー登録機能を作成するに当たって使用変更した部分は修正した。

# Why
出品状態を区別するテーブルの作成に当たってデータベースの再設計が必要となったため。