### PR TITLE
売却済みテーブルの作成

### DIFF
--- a/app/models/soldout.rb
+++ b/app/models/soldout.rb
@@ -1,0 +1,4 @@
+class Soldout < ApplicationRecord
+  belongs_to :item
+  belongs_to :user
+end

--- a/db/migrate/20200927061950_create_soldouts.rb
+++ b/db/migrate/20200927061950_create_soldouts.rb
@@ -1,0 +1,9 @@
+class CreateSoldouts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :soldouts do |t|
+      t.integer :user_id,        null: false, foreign_key: true
+      t.integer :item_id,        null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_07_114227) do
+ActiveRecord::Schema.define(version: 2020_09_27_061950) do
+
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prefecture_id"
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_name_reading", null: false
+    t.string "first_name_reading", null: false
+    t.string "city", null: false
+    t.integer "address", null: false
+    t.integer "zip_code", null: false
+    t.string "building"
+    t.integer "phone"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -28,6 +44,14 @@ ActiveRecord::Schema.define(version: 2020_09_07_114227) do
     t.string "phone"
     t.integer "user_id", null: false
     t.integer "residency_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "credit_cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "cutomer_id", null: false
+    t.string "card_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -67,6 +91,13 @@ ActiveRecord::Schema.define(version: 2020_09_07_114227) do
     t.string "building"
     t.string "phone"
     t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "soldouts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/soldouts.rb
+++ b/spec/factories/soldouts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :soldout do
+    
+  end
+end

--- a/spec/models/soldout_spec.rb
+++ b/spec/models/soldout_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Soldout, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
商品情報として、出品中と売却済みを区別するために売却済みテーブルを作成した。カラムにはitem_idとuser_idを格納し商品に加えユーザー情報も登録できるようにした。出品中はテーブルとして管理せず、売却済みでない商品を出品中とする。

# Why
出品中と売却済みを区別して商品を管理するため。