### PR TITLE
カード登録、削除機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 public/uploads/*
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,5 @@ gem 'mini_magick'
 gem "jquery-rails"
 gem 'rails-i18n'
 gem 'fog-aws'
+gem 'dotenv-rails'
+gem 'payjp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,12 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.9.0)
     erubis (2.7.0)
     excon (0.76.0)
@@ -158,6 +164,9 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     image_processing (1.11.0)
@@ -198,10 +207,13 @@ GEM
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
+    netrc (0.11.0)
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    payjp (0.0.7)
+      rest-client (~> 2.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -248,6 +260,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -315,6 +332,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicorn (5.6.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -350,6 +370,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   factory_bot_rails
   fog-aws
   font-awesome-sass
@@ -359,6 +380,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
+  payjp
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/app/assets/javascripts/items.coffee
+++ b/app/assets/javascripts/items.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,0 +1,32 @@
+document.addEventListener(
+  'turbolinks:load', e => {
+    if ($("#card_form") != null) {
+      Payjp.setPublicKey("pk_test_5c336f11e15630f0b243cfd3");
+      const submitBtn = $("#token_submit")
+      submitBtn.on("click", (e) => {
+        e.preventDefault();
+        let card = {
+          number: document.getElementById("card_number").value,
+          cvc: document.getElementById("card_cvc").value,
+          exp_month: document.getElementById("card_exp_month").value,
+          exp_year: document.getElementById("card_exp_year").value
+        };
+        Payjp.createToken(card, (status, response) => {
+          if (status === 200) {
+            $("#card_number").removeAttr("name");
+            $("#card_cvc").removeAttr("name");
+            $("#card_exp_month").removeAttr("name");
+            $("#card_exp_year").removeAttr("name");
+            $("#card_token").append(
+              $('<input type="hidden" name="payjp-token">').val(response.id)
+            );
+            alert("登録が完了しました");
+            $("#card_form")[0].submit();
+          } else {
+            alert("カード情報が正しくありません。");
+          }
+        });
+      });
+    }
+  }
+);

--- a/app/assets/javascripts/registrations.coffee
+++ b/app/assets/javascripts/registrations.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/_cardlist.scss
+++ b/app/assets/stylesheets/_cardlist.scss
@@ -1,0 +1,44 @@
+.content{
+  background-color: #f2f2f2;
+  height: 500px;
+  width: 700px;
+  margin-top: 50px;
+  &__cards {
+    height: 100px;
+    text-align: center;
+    font-size: 30px;
+    font-weight: bold;
+    line-height: 100px;
+    border-bottom: 1px solid white;
+    &__list {
+      padding-top:30px;
+      &__pay {
+        font-size:20px;
+        padding-top:10px;
+       &__num {
+         font-size: 16px;
+       }
+      }
+      &__remove {
+        width: 450px;
+        text-align:center;
+        background-color: #3ccace;
+        margin-top:30px;
+        margin-left:150px;
+        height:50px;
+        color:black;
+        font-weight: bold;
+      }
+    }
+  }
+  &__newcard {
+    padding:30px 0px;
+    border-bottom: 1px solid white;
+  }
+}
+
+.link-newcard {
+  color: #0095ee;
+  text-decoration: none;
+  display: block;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,4 @@
 @import "new-items";
 @import "buy";
 @import "show";
+@import "cardlist";

--- a/app/assets/stylesheets/newcredit.scss
+++ b/app/assets/stylesheets/newcredit.scss
@@ -62,6 +62,7 @@
     width: 450px;
     background-color: #3ccace;
     height:50px;
+    text-align:center;
     color:black;
     font-weight: bold;
   }

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,0 +1,62 @@
+class CardsController < ApplicationController
+  before_action :set_category
+  before_action :set_card
+
+  require "payjp"
+
+  def index
+  end
+
+  def new
+    @card = Card.new
+  end
+
+
+  def create
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    if params['payjp-token'].blank?
+      redirect_to action: :new
+    else
+      customer = Payjp::Customer.create(
+        email: current_user.email,
+        card: params['payjp-token'],
+        metadata: {user_id: current_user.id} 
+      )
+      @card = Card.new(user: current_user, customer_id: customer.id, card_id: customer.default_card)
+      if @card.save
+        redirect_to card_path(current_user)
+      else
+        redirect_to action: :new
+      end
+    end
+  end
+
+  def show
+    if @card.present?
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      @card_information = customer.cards.retrieve(@card.card_id)
+    end
+  end
+
+  def destroy
+    customer = Payjp::Customer.retrieve(@card.customer_id)
+    customer.delete
+    if @card.destroy
+      redirect_to action: :index, notice: "削除しました"
+    else
+      redirect_to action: :index, alert: "削除できませんでした"
+    end
+  end
+
+
+  private
+ 
+  def set_category
+    @parent = Category.where(ancestry: nil)
+  end
+
+  def set_card
+    @card = Card.where(user_id: current_user.id).first if Card.where(user_id: current_user.id).present?
+  end
+end

--- a/app/helpers/card_helper.rb
+++ b/app/helpers/card_helper.rb
@@ -1,0 +1,2 @@
+module CardHelper
+end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,0 +1,3 @@
+class Card < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
                 :recoverable, :rememberable, :validatable
         has_many :items
         has_one :residency, dependent: :delete
+        has_one :card, dependent: :delete
 
         #以下はフリマのバリデーションコード
         with_options presence: true do

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -1,14 +1,14 @@
 =render 'items/header'
 .user-page
-  =render 'sidebar'
+  =render 'users/sidebar'
   .paymethod
     .paymethod__payinfo
       支払い方法
     .paymethod__credit
       クレジットカード
     .paymethod__register
-      =link_to "新規カードを登録する" ,newcredit_user_url(current_user) ,class: "link-register"
+      =link_to "新規カードを登録する" ,new_card_path,class: "link-register"
     .paymethod__confirmation
       .paymethod__confirmation__change
-        =link_to "登録情報の確認および変更" , "#" ,class: "link-change"
+        =link_to "登録情報の確認および変更" , card_path(current_user),class: "link-change"
 =render 'items/footer'

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,16 +1,16 @@
 =render 'items/header'
 .user-page
-  =render 'sidebar'
+  =render 'users/sidebar'
   .creditinport
     .creditinport__title
       クレジットカード情報入力
     .creditinport__credit-card
     .creditinport__credit-card__inner
-      = form_with url: "#", method: :post, html: { name: "inputForm" } do |f|
+      = form_with model: @card, method: :post, html: { name: "inputForm", id: "card_form"} do |f|
         = f.label :カード番号, class: 'label'
         %span.required 必須
         %br
-        = f.text_field :card_number, type: 'text', class: 'input-number', placeholder: '半角数字のみ', maxlength: "16"
+        = f.text_field :number, type: 'text', class: 'input-number', placeholder: '半角数字のみ', maxlength: "16"
         .card-deadline
           = f.label :有効期限, class: 'deadline'
           %span.required 必須
@@ -27,5 +27,5 @@
           %br
           = f.text_field :cvc, type: 'text', class: 'input-number', placeholder: 'カード背面4桁もしくは3桁の番号', maxlength: "4"
         .add_card#card_token
-          = f.submit '追加する', class: 'add-btn', id: 'token_submit' #tokenというidを使うとpayjpの実装の時便利そう。
+          = f.submit '追加する', class: 'add-btn', id: 'token_submit' 
 =render 'items/footer'

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,0 +1,25 @@
+=render 'items/header'
+.user-page
+  =render 'users/sidebar'
+  .content
+    .content__cards
+      %h1 クレジットカード一覧
+    - if @card.present?
+      %ul.content__cards__list
+        %li
+          = form_with url: card_path(@card.id), method: :delete, local: true, id: 'charge-form' do |f|
+            .content__cards__list__pay
+              クレジットカード番号(下4桁のみ表示)
+            .content__cards__list__pay__num
+              = "**** **** **** " + @card_information.last4
+            .content__cards__list__pay
+              カード有効期限(月/年)
+            .content__cards__list__pay__num
+              - exp_month = @card_information.exp_month.to_s
+              - exp_year = @card_information.exp_year.to_s.slice(2,3)
+              = exp_month + " / " + exp_year
+            %input{type: "hidden", name: "card_id", value: ""}
+            = f.submit "削除する", {class: "content__cards__list__remove"}
+    .content__newcard
+      =link_to "新規カードを登録する" ,new_card_path,class: "link-newcard"
+=render 'items/footer'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,6 +3,7 @@
   %head
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title FleamarketSample77d
+    %script{src: "https://js.pay.jp/v1", type: "text/javascript"}
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/app/views/users/_sidebar.html.haml
+++ b/app/views/users/_sidebar.html.haml
@@ -29,7 +29,7 @@
       %li
         =link_to "発送元・お届け住所変更", "#" ,class: "link-text"
       %li
-        =link_to "支払い方法", paymethod_user_url(current_user) ,class: "link-text"
+        =link_to "支払い方法", cards_path(current_user),class: "link-text"
       %li
         =link_to "メール/パスワード変更", "#" ,class: "link-text"
       %li

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,5 @@ Rails.application.routes.draw do
 
   resources :users
   resources :images
-  resources :cards
+  resources :cards, only: [:new, :create, :index, :destroy, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,12 +15,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users do
-    member do
-      get 'paymethod'
-      get 'newcredit'
-    end
-  end
+  resources :users
   resources :images
-
+  resources :cards
 end

--- a/db/migrate/20201004022018_create_cards.rb
+++ b/db/migrate/20201004022018_create_cards.rb
@@ -1,0 +1,10 @@
+class CreateCards < ActiveRecord::Migration[5.2]
+  def change
+    create_table :cards do |t|
+      t.integer :user_id, null: false
+      t.string :customer_id, null: false
+      t.string :card_id, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema.define(version: 2020_10_04_022018) do
 
-ActiveRecord::Schema.define(version: 2020_09_27_061950) do
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "prefecture_id"
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_name_reading", null: false
+    t.string "first_name_reading", null: false
+    t.string "city", null: false
+    t.integer "address", null: false
+    t.integer "zip_code", null: false
+    t.string "building"
+    t.integer "phone"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
+  create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "customer_id", null: false
+    t.string "card_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -20,6 +48,18 @@ ActiveRecord::Schema.define(version: 2020_09_27_061950) do
     t.datetime "updated_at", null: false
     t.string "ancestry"
     t.index ["ancestry"], name: "index_categories_on_ancestry"
+  end
+
+  create_table "consignors", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "family_name", null: false
+    t.string "family_kana", null: false
+    t.string "name", null: false
+    t.string "name_kana", null: false
+    t.string "phone"
+    t.integer "user_id", null: false
+    t.integer "residency_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/factories/cards.rb
+++ b/spec/factories/cards.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :card do
+    
+  end
+end

--- a/spec/helpers/card_helper_spec.rb
+++ b/spec/helpers/card_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CardHelper. For example:
+#
+# describe CardHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CardHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Card, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/card_request_spec.rb
+++ b/spec/requests/card_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Cards", type: :request do
+
+end


### PR DESCRIPTION
# What
payjpを使用したクレジットカードの登録及び支払いのため、カード情報はjavascriptを使用しトークン化、データベースにはpayjpからのカードid、カスタマーidが格納されるようにした。登録情報を表示すると、payjpから登録されたカード情報と、有効期限を表示させ、削除するとデータベース、トークン共に削除できるようコントローラーを指定した。
(バリデーション、テスト、エラーハンドリングについては現状は未実装です)

# Why
フリーマーケットアプリの利用においてクレジットカードの利用、登録は必須であるため。