### PR TITLE
itemモデルのバリデーション修正

### DIFF
--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -111,6 +111,9 @@
           font-size: 15px;
           list-style: none;
           border: 2px solid #f2f2f2;
+          a {
+            color: #0095ee;
+          }
         }
       }
     }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,17 +45,9 @@ class ItemsController < ApplicationController
       redirect_to edit_item_path, notice: '出品情報の更新が完了しました'
     else
       flash.now[:alert] = "入力内容漏れがあります。下記を参照に修正してください。"
-      if params[:item][:images_attributes].blank?
-        @item.images.build
-        render action: :edit
-      else
-      @item.images = [@item.images.new]
       render action: :edit
-      end
     end
   end
-
-
 
   def destroy
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,7 @@ class Item < ApplicationRecord
     validates :name,
       length: {maximum: 40}
     validates :price,
-      inclusion: {in: 1..9999999}
+      numericality: {greater_than_or_equal_to: 1, less_than_or_equal_to: 9999999}
     validates :explanation,
       length: {maximum: 1000} 
     validates :delivery_day_id 

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -21,7 +21,7 @@
                     %span.js-remove 削除
                     %span.js-edit{data: {index: i}} 編集
 
-            %label.image-label{for: "item_images_attributes_#{@item.images.length}_url"}
+            %label.image-label{for: "item_images_attributes_#{@item.images.length-1}_url"}
               .items__image__upload__comment
                 %i.fas.fa-camera 
                   %p クリックしてファイルをアップロード
@@ -30,7 +30,7 @@
                   = image.file_field :url, class: "js-file"
                 - if @item.persisted?
                   .js-file_group{data: {index: @item.images.count}}
-                    = file_field_tag :url, name: "item[images_attributes][#{@item.images.count}][url]", class: 'js-file', id: "item_images_attributes_#{@item.images.length}_url"
+                    = file_field_tag :url, name: "item[images_attributes][#{@item.images.count}][url]", class: 'js-file', id: "item_images_attributes_#{@item.images.length-1}_url"
                     - if image.object.persisted?
                       = image.check_box :_destroy, class: 'hidden-destroy', data: {index: image.index}
 

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -25,9 +25,7 @@
       %ul.transaction__list 
         - current_user.items.each do |item|
           %li.transaction__now
-            -# = item.images.first
             = image_tag item.images.first.url.url, size: '120×120'
-            -# %img{src: item.images.first, height:"120", width: "120"}
             %p 商品名
             = item.name
             %p 販売価格(税込み)


### PR DESCRIPTION
WHAT
・itemモデルの価格が０円でも登録可能になっていたので、修正（最低１円以上）しました。
・itemコントローラーのupdateアクションの際に、更新エラーがかかると画像が消えてしまう不具合を修正しました
・マイページの登録済み商品からのリンクに色をつけました
・コメントアウトのままだった不要なコードを削除しました