### PR TITLE
商品一覧表示の実装

### DIFF
--- a/app/assets/stylesheets/_pickup.scss
+++ b/app/assets/stylesheets/_pickup.scss
@@ -15,6 +15,7 @@
       color:black;
       &__product {
         background-color: white;
+        display:flex;
         &__body {
           font-weight: normal;
           &__name {
@@ -37,8 +38,14 @@
   }
 }
 
-.category-link {
+.listBtn{
   text-decoration: none;
+  color:black;
+  display: inline-block;
+  background-color: white;
+}
+
+.category-link {
   color:#3CCACE;
 }
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :show, :update]
 
   def index
+    @newItems = Item.includes(:images).order("created_at DESC").limit(5)
     @parent = Category.where(ancestry: nil)
   end
 

--- a/app/views/items/_pickup-category.html.haml
+++ b/app/views/items/_pickup-category.html.haml
@@ -1,62 +1,20 @@
 .pickup
   .pickup__content
-    ピックアップカテゴリー
+    ピックアップ商品
     .pickup__content__new
-      =link_to "新規投稿商品", "#" , class:"category-link"
-  =link_to  "#" do
+      =link_to "新規登録商品", "#" , class:"category-link"
     %ul.pickup__content__list
-      %li.pickup__content__list__product
-        .pickup__content__list__product__head
-          .pickup__content__list__product__head__image
-            =image_tag "product1.jpeg", size:"220x150", class: "product-img"
-        .pickup__content__list__product__body
-          .pickup__content__list__product__body__name
-            テスト1
-          .pickup__content__list__product__body__money
-            1000円
-          .pickup__content__list__product__body__tax
-            (税込)
-      %li.pickup__content__list__product
-        .pickup__content__list__product__head
-          .pickup__content__list__product__head__image
-            =image_tag "product1.jpeg", size:"220x150", class: "product-img"
-        .pickup__content__list__product__body
-          .pickup__content__list__product__body__name
-            テスト2
-          .pickup__content__list__product__body__money
-            2000円
-          .pickup__content__list__product__body__tax
-            (税込)
-      %li.pickup__content__list__product
-        .pickup__content__list__product__head
-          .pickup__content__list__product__head__image
-            =image_tag "product1.jpeg", size:"220x150", class: "product-img"
-        .pickup__content__list__product__body
-          .pickup__content__list__product__body__name
-            テスト3
-          .pickup__content__list__product__body__money
-            3000円
-          .pickup__content__list__product__body__tax
-            (税込)
-      %li.pickup__content__list__product
-        .pickup__content__list__product__head
-          .pickup__content__list__product__head__image
-            =image_tag "product1.jpeg", size:"220x150", class: "product-img"
-        .pickup__content__list__product__body
-          .pickup__content__list__product__body__name
-            テスト4
-          .pickup__content__list__product__body__money
-            4000円
-          .pickup__content__list__product__body__tax
-            (税込)
-      %li.pickup__content__list__product
-        .pickup__content__list__product__head
-          .pickup__content__list__product__head__image
-            =image_tag "product1.jpeg", size:"220x150", class: "product-img"
-        .pickup__content__list__product__body
-          .pickup__content__list__product__body__name
-            テスト5
-          .pickup__content__list__product__body__money
-            5000円
-          .pickup__content__list__product__body__tax
-            (税込)
+      - @newItems.each do |item|
+        %li.pickup__content__list__product
+          =link_to item_path(item.id), class: "listBtn" do
+            .pickup__content__list__product__head
+              .pickup__content__list__product__head__image
+                =image_tag item.images.first.url.url, alt: "image_url", size:"220x150", class: "product-img"
+            .pickup__content__list__product__body
+              .pickup__content__list__product__body__name
+                = item.name
+              .pickup__content__list__product__body__money
+                = item.price 
+                円
+              .pickup__content__list__product__body__tax
+                (税込)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -4,7 +4,6 @@
 =render 'membership'
 =render 'feature'
 =render 'pickup-category'
-=render 'pickup-brand'
 =render 'downroad'
 =render 'footer'
 =render 'exhibitionbtn'


### PR DESCRIPTION
# What
トップページに表示される商品一覧表示として、ユーザーによらず登録された商品の最新5件が表示されるようにした。コントローラーにincludeメソッドを使用し、降順で左から順に表示されるようビューを調整した。またそれぞれの詳細ページに移動できるようリンクを設定した。（まずは全商品の一覧から実装したため、ブランド、カテゴリーごとの表示は未実装です。画像は現在のビューです。)

# Why
フリーマーケットアプリにおいて商品一覧表示は購買意欲に繋がる、また運営の状況を把握しやすいため。

<img width="1424" alt="商品表示機能" src="https://user-images.githubusercontent.com/66421065/95365745-81b0bb00-090d-11eb-84bd-2e3580ada727.png">
