### PR TITLE
商品購入機能の実装

### DIFF
--- a/app/assets/stylesheets/buy.scss
+++ b/app/assets/stylesheets/buy.scss
@@ -131,13 +131,12 @@
 }
 
 .purchase__btn {
-  margin-top:10px;
   display: block;
   line-height: 48px;      
   font-size: 16px;
   font-weight: bold;
   align-items: center;
-  border-radius: 4px;
+  margin-top:50px;
   margin-bottom: 24px;
   cursor: pointer;
   text-decoration: none;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :show, :update, :buy]
-  before_action :set_card
+  before_action :set_item, only: [:edit, :show, :update, :buy, :pay]
+  before_action :set_card, only: [:buy, :pay]
 
   require "payjp"
 
@@ -71,6 +71,19 @@ class ItemsController < ApplicationController
       customer = Payjp::Customer.retrieve(@card.customer_id)
       @card_information = customer.cards.retrieve(@card.card_id)
     end
+  end
+
+  def pay
+    @card = set_card
+    Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
+    customer = Payjp::Customer.retrieve(@card.customer_id)
+    Payjp::Charge.create(
+    :amount => @item.price,
+    :customer => @card.customer_id,
+    :currency => 'jpy',
+    )
+    Soldout.create(item_id: @item.id, user_id: current_user.id)
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -78,9 +78,9 @@ class ItemsController < ApplicationController
     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
     customer = Payjp::Customer.retrieve(@card.customer_id)
     Payjp::Charge.create(
-    :amount => @item.price,
-    :customer => @card.customer_id,
-    :currency => 'jpy',
+    amount: @item.price,
+    customer: @card.customer_id,
+    currency: 'jpy',
     )
     if Soldout.create(item_id: @item.id, user_id: current_user.id)
       redirect_to root_path, notice: '商品の購入が完了しました'

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -82,8 +82,11 @@ class ItemsController < ApplicationController
     :customer => @card.customer_id,
     :currency => 'jpy',
     )
-    Soldout.create(item_id: @item.id, user_id: current_user.id)
-    redirect_to root_path
+    if Soldout.create(item_id: @item.id, user_id: current_user.id)
+      redirect_to root_path, notice: '商品の購入が完了しました'
+    else
+      flash.now[:alert] = '商品が購入できませんでした。'
+    end
   end
 
   private

--- a/app/models/soldout.rb
+++ b/app/models/soldout.rb
@@ -1,4 +1,4 @@
 class Soldout < ApplicationRecord
-  belongs_to :item
-  belongs_to :user
+  belongs_to :item, optional: true
+  belongs_to :user, optional: true
 end

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -57,7 +57,9 @@
             - exp_year = @card_information.exp_year.to_s.slice(2,3)
             = exp_month + " / " + exp_year
             %br
-            .purchase__btn 購入する
+            .purchase
+              = form_tag(action: :pay, method: :post, item_id: @item) do
+                %button.purchase__btn 購入を確定する
         - else
           =link_to "新規カードを登録する" ,new_card_path
           .buy__wrapper__purchase

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -78,11 +78,16 @@
                   = icon('fas', 'far fa-trash-alt')
                   削除する
           - elsif user_signed_in?
-            .optionalBtnlikeBtn
-              %span.purchaseBtn__text
-                = link_to buy_item_path(@item) do
-                  = icon('fas', 'cart-arrow-down fa-2x')
-                  購入する
+            - if @item.soldout
+              .optionalBtnlikeBtn
+                %span.purchaseBtn__text
+                  売り切れ
+            - else
+              .optionalBtnlikeBtn
+                %span.purchaseBtn__text
+                  = link_to buy_item_path(@item) do
+                    = icon('fas', 'cart-arrow-down fa-2x')
+                    購入する
           - else 
             .optionalBtnlikeBtn
               %span.purchaseBtn__text

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     end
     member do
       get 'buy'
+      post 'pay'
     end
   end
 


### PR DESCRIPTION
# What
payjpからクレジットカード情報を取得し、商品が購入できるよう実装した。itemのコントローラーでpayメソッドを実行し、取得した商品の値段が支払いできるようになっている。またpayjpで売り上げとして商品の価格が正しく上がっていることを確認した。

# Why
フリーマーケットアプリにおいてクレジットカードでの商品購入は必須であるため。