### PR TITLE
Update items_controller.rb

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,6 +52,7 @@ class ItemsController < ApplicationController
       redirect_to root_path, notice: '出品情報の更新が完了しました'
     else
       flash.now[:alert] = "入力内容漏れがあります。下記を参照に修正してください"
+      @item.images.build
       render action: :edit
     end
   end


### PR DESCRIPTION
WHAT
編集画面でバリデーションエラーを発生させると画像投稿の挙動がおかしくなるエラー（最後の画像との差し替えになる。新たに画像を加えられない問題）を解消しました。

WHY
サーバーサイドチェックリスト項目のため